### PR TITLE
chore: add tailwind regex

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -48,6 +48,11 @@
     "examples/erp/src/app/(admin)/admin/tailwind.css": "examples/erp/(admin)/**",
     "examples/erp/src/app/(admin)/playground/tailwind.css": "examples/erp/(admin)/playground/**"
   },
+  "tailwindCSS.experimental.classRegex": [
+    ["clsx\\(.*?\\)(?!\\])", "(?:'|\"|`)([^\"'`]*)(?:'|\"|`)"],
+    ["(?:twMerge|twJoin|cn)\\(([^;]*)[\\);]", "[`'\"`]([^'\"`;]*)[`'\"`]"],
+    ["tv\\(([^)]*)\\)", "{?\\s?[\\w].*:\\s*?[\"'`]([^\"'`]*).*?,?\\s?}?"]
+  ],
   "[sql]": {
     "editor.defaultFormatter": "adpyke.vscode-sql-formatter"
   }


### PR DESCRIPTION
Ref: https://github.com/paolotiu/tailwind-intellisense-regex-list


Note:
Some of the class name can break the plugin lol
`shadow-[0_0_0_0.8px_var(--color-primary-emphasis),0_1px_3px_0_var(--color-primary),inset_0_1.5px_0_0_--alpha(var(--color-white)/20%)]`