### PR TITLE
feat: :label: export `ToClientCollection` type from `./collection`

### DIFF
--- a/.changeset/plenty-zebras-smile.md
+++ b/.changeset/plenty-zebras-smile.md
@@ -1,0 +1,5 @@
+---
+"@genseki/react": minor
+---
+
+:label: export `ToClientCollection` type from `./collection`

--- a/packages/react/src/core/index.ts
+++ b/packages/react/src/core/index.ts
@@ -20,6 +20,7 @@ export type {
   InferFullSchemaFromCollection,
   InferSlugFromCollection,
   InferTableNameFromCollection,
+  ToClientCollection,
 } from './collection'
 export { ApiDefaultMethod } from './collection'
 export type { AnyServerConfig, BaseConfig, ClientConfig, ServerConfig } from './config'


### PR DESCRIPTION
# Why?

Exporting `ToClientCollection` will help the custom client infer a type of omitted `_`, `admin` from the collection configuration.