### PR TITLE
Fix catch error in NextJS resource route

### DIFF
--- a/.changeset/tiny-schools-type.md
+++ b/.changeset/tiny-schools-type.md
@@ -1,0 +1,5 @@
+---
+'@genseki/next': patch
+---
+
+Fix catching error in nextjs resource route

--- a/packages/next/src/resource.ts
+++ b/packages/next/src/resource.ts
@@ -50,21 +50,31 @@ async function makeApiRoute(
   const { context: authContext } = createAuth(serverConfig.auth, serverConfig.context)
   const context = Context.toRequestContext(authContext, reqHeaders)
 
-  const rawResponse = await route.handler({
-    context,
-    headers: reqHeaders,
-    pathParams: pathParams,
-    query: reqSearchParams,
-    body,
-  })
+  try {
+    const rawResponse = await route.handler({
+      context,
+      headers: reqHeaders,
+      pathParams: pathParams,
+      query: reqSearchParams,
+      body,
+    })
 
-  return new Response(JSON.stringify(rawResponse.body) as any, {
-    status: rawResponse.status,
-    headers: {
-      'Content-Type': 'application/json',
-      ...rawResponse.headers,
-    },
-  })
+    return new Response(JSON.stringify(rawResponse.body) as any, {
+      status: rawResponse.status,
+      headers: {
+        'Content-Type': 'application/json',
+        ...rawResponse.headers,
+      },
+    })
+  } catch (error: any) {
+    console.error('Error in API route:', error)
+    return Response.json(
+      {
+        message: error.message || 'Internal Server Error',
+      },
+      { status: error.status || 500 }
+    )
+  }
 }
 
 async function lookupRoute(


### PR DESCRIPTION
# Why did you create this PR

<!-- Please add a link of the Ticket -->

- When throw error in NextJS resource route. It will return `text` Response instead of `json` which cause error in React Query and Rest Client 

# What did you do

- Catch error and return it as a JSON instead of text

# Screenshots / Recordings

# Checklist

- [ ] Self-reviewed your code
- [ ] Wrote coverage tests
- [ ] Added screenshots or recordings if applicable
