### PR TITLE
fix: :coffin: remove user collection from plugin

### DIFF
--- a/.changeset/sixty-dryers-battle.md
+++ b/.changeset/sixty-dryers-battle.md
@@ -1,0 +1,5 @@
+---
+"@genseki/plugins": patch
+---
+
+fix: :coffin: remove user collection from plugin

--- a/packages/plugins/src/admin/index.ts
+++ b/packages/plugins/src/admin/index.ts
@@ -111,31 +111,6 @@ export function admin<TContext extends Context<FullSchema>>(
   const schema = baseConfig.schema
   const builder = new Builder({ schema: baseConfig.schema }).$context<typeof baseConfig.context>()
 
-  const userCollection = builder.collection('user', {
-    slug: 'user',
-    identifierColumn: 'id',
-    fields: builder.fields('user', (fb) => ({
-      name: fb.columns('name', {
-        type: 'text',
-      }),
-      email: fb.columns('email', {
-        type: 'text',
-      }),
-      role: fb.columns('role', {
-        type: 'text',
-      }),
-      banned: fb.columns('banned', {
-        type: 'checkbox',
-      }),
-      bannedReason: fb.columns('bannedReason', {
-        type: 'text',
-      }),
-      bannedExpiresAt: fb.columns('bannedExpiresAt', {
-        type: 'date',
-      }),
-    })),
-  })
-
   const hasPermissionEndpoint = builder.endpoint(
     {
       method: 'POST',
@@ -223,10 +198,6 @@ export function admin<TContext extends Context<FullSchema>>(
     plugin: (input) => {
       return {
         ...input,
-        collections: {
-          ...input.collections,
-          user: userCollection,
-        },
         endpoints: {
           ...input.endpoints,
           'auth.hasPermission': hasPermissionEndpoint,


### PR DESCRIPTION
# Why did you create this PR

By private discussion with @saenyakorn, we decided to remove an overriding `collections` configuration: **user** from the plugin

# What did you do

- remove `user` 

# Screenshots / Recordings

# Checklist

- [x] Self-reviewed your code
- [ ] Wrote coverage tests
- [ ] Added screenshots or recordings if applicable
