### PR TITLE
[Fix] plugin type and make `userId` in verification optional

### DIFF
--- a/.changeset/friendly-spies-speak.md
+++ b/.changeset/friendly-spies-speak.md
@@ -1,0 +1,7 @@
+---
+"@example/erp": patch
+"@genseki/plugins": patch
+"@genseki/react": patch
+---
+
+[Fix] plugin type and make `userId` in verification to be optional

--- a/examples/erp/prisma/migrations/20250801080125_make_user_id_optional_in_verification_table/migration.sql
+++ b/examples/erp/prisma/migrations/20250801080125_make_user_id_optional_in_verification_table/migration.sql
@@ -1,0 +1,8 @@
+-- DropForeignKey
+ALTER TABLE "Verification" DROP CONSTRAINT "Verification_userId_fkey";
+
+-- AlterTable
+ALTER TABLE "Verification" ALTER COLUMN "userId" DROP NOT NULL;
+
+-- AddForeignKey
+ALTER TABLE "Verification" ADD CONSTRAINT "Verification_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE SET NULL ON UPDATE CASCADE;

--- a/examples/erp/prisma/schema.prisma
+++ b/examples/erp/prisma/schema.prisma
@@ -90,8 +90,8 @@ model Session {
 model Verification {
   id String @id @default(uuid())
 
-  userId String
-  user   User   @relation(fields: [userId], references: [id])
+  userId String?
+  user   User?   @relation(fields: [userId], references: [id])
 
   value      String
   identifier String   @unique

--- a/packages/plugins/src/admin/index.ts
+++ b/packages/plugins/src/admin/index.ts
@@ -31,18 +31,22 @@ type AccessControlStatements = {
   [K in string]: string[] | AccessControlStatements
 }
 
+export type AnyPluginSchema = {
+  user: any
+}
+
 type PluginSchema = {
   user: AnyUserTable
 }
 
-type ValidateSchema<TSchema extends PluginSchema> = {
-  user: IsValidTable<AnyUserTable, TSchema['user']>
+type ValidateSchema<TSchema extends AnyPluginSchema> = {
+  user: IsValidTable<PluginSchema['user'], TSchema['user']>
 } extends {
   user: true
 }
   ? AdminPluginOptions
   : {
-      user: IsValidTable<AnyUserTable, TSchema['user']>
+      user: IsValidTable<PluginSchema['user'], TSchema['user']>
     }
 
 export interface AdminPluginOptions {
@@ -138,7 +142,7 @@ function isOptions(options: any): options is AdminPluginOptions {
   return !('user' in options)
 }
 
-export function admin<TContext extends AnyContextable, TSchema extends PluginSchema>(
+export function admin<TContext extends AnyContextable, TSchema extends AnyPluginSchema>(
   context: TContext,
   schema: TSchema,
   options: ValidateSchema<TSchema>

--- a/packages/react/src/auth/base.ts
+++ b/packages/react/src/auth/base.ts
@@ -61,7 +61,7 @@ export type AnyVerificationTable = AnyTable<{
     id: WithHasDefaultValue<WithIsRequired<AnyTypedFieldColumn<typeof DataType.STRING>>>
     identifier: WithIsRequired<AnyTypedFieldColumn<typeof DataType.STRING>>
     value: AnyTypedFieldColumn<typeof DataType.STRING>
-    userId: WithIsRequired<AnyTypedFieldColumn<typeof DataType.STRING>>
+    userId: AnyTypedFieldColumn<typeof DataType.STRING>
     expiredAt: WithIsRequired<AnyTypedFieldColumn<typeof DataType.DATETIME>>
     createdAt: WithHasDefaultValue<WithIsRequired<AnyTypedFieldColumn<typeof DataType.DATETIME>>>
   }

--- a/packages/react/src/auth/plugins/email-and-password/index.tsx
+++ b/packages/react/src/auth/plugins/email-and-password/index.tsx
@@ -28,6 +28,13 @@ import type {
   AnyVerificationTable,
 } from '../../base'
 
+export type AnyPluginSchema = {
+  user: any
+  session: any
+  account: any
+  verification: any
+}
+
 export type PluginSchema = {
   user: AnyUserTable
   session: AnySessionTable
@@ -35,11 +42,11 @@ export type PluginSchema = {
   verification: AnyVerificationTable
 }
 
-type ValidateSchema<TSchema extends PluginSchema> = {
-  user: IsValidTable<AnyUserTable, TSchema['user']>
-  session: IsValidTable<AnySessionTable, TSchema['session']>
-  account: IsValidTable<AnyAccountTable, TSchema['account']>
-  verification: IsValidTable<AnyVerificationTable, TSchema['verification']>
+type ValidateSchema<TSchema extends AnyPluginSchema> = {
+  user: IsValidTable<PluginSchema['user'], TSchema['user']>
+  session: IsValidTable<PluginSchema['session'], TSchema['session']>
+  account: IsValidTable<PluginSchema['account'], TSchema['account']>
+  verification: IsValidTable<PluginSchema['verification'], TSchema['verification']>
 } extends {
   user: true
   session: true
@@ -48,10 +55,10 @@ type ValidateSchema<TSchema extends PluginSchema> = {
 }
   ? EmailAndPasswordPluginOptions
   : {
-      user: IsValidTable<AnyUserTable, TSchema['user']>
-      session: IsValidTable<AnySessionTable, TSchema['session']>
-      account: IsValidTable<AnyAccountTable, TSchema['account']>
-      verification: IsValidTable<AnyVerificationTable, TSchema['verification']>
+      user: IsValidTable<PluginSchema['user'], TSchema['user']>
+      session: IsValidTable<PluginSchema['session'], TSchema['session']>
+      account: IsValidTable<PluginSchema['account'], TSchema['account']>
+      verification: IsValidTable<PluginSchema['verification'], TSchema['verification']>
     }
 
 interface EmailAndPasswordPluginOptions {
@@ -117,7 +124,7 @@ function isOptions(options: any): options is EmailAndPasswordPluginOptions {
 
 export function emailAndPasswordPlugin<
   TContext extends AnyContextable,
-  TSchema extends PluginSchema,
+  TSchema extends AnyPluginSchema,
   TOptions extends ValidateSchema<TSchema>,
 >(context: TContext, schema: TSchema, _options: TOptions) {
   if (!isOptions(_options)) {

--- a/packages/react/src/auth/plugins/email-and-password/service.ts
+++ b/packages/react/src/auth/plugins/email-and-password/service.ts
@@ -6,7 +6,6 @@ import type { AnyContextable } from '../../../core/context'
 import { HttpInternalServerError } from '../../../core/error'
 import type { MockPrismaClient } from '../../../core/prisma.types'
 import type { InferTableType } from '../../../core/table'
-import type { AnyAccountTable, AnyUserTable, AnyVerificationTable } from '../../base'
 
 export class EmailAndPasswordService<TContext extends AnyContextable> {
   private readonly prisma: MockPrismaClient
@@ -32,13 +31,13 @@ export class EmailAndPasswordService<TContext extends AnyContextable> {
       where: {
         [emailField.name]: email,
       },
-    })) as InferTableType<AnyUserTable> | undefined
+    })) as InferTableType<PluginSchema['user']> | undefined
 
     if (!user) throw new HttpInternalServerError('User not found')
 
     const account = (await this.prisma[this.schema.account.config.prismaModelName].findFirst({
       where: { accountId: user.id, provider: AccountProvider.CREDENTIAL },
-    })) as InferTableType<AnyAccountTable> | undefined
+    })) as InferTableType<PluginSchema['account']> | undefined
 
     if (!account) throw new HttpInternalServerError('Account not found')
     if (!account.password)
@@ -84,7 +83,7 @@ export class EmailAndPasswordService<TContext extends AnyContextable> {
     const emailField = this.schema.user.shape.columns.email
     const user = (await this.prisma[this.schema.user.config.prismaModelName].findUnique({
       where: { [emailField.name]: email },
-    })) as InferTableType<AnyUserTable> | undefined
+    })) as InferTableType<PluginSchema['user']> | undefined
 
     if (!user) {
       throw new HttpInternalServerError('User not found')
@@ -129,7 +128,7 @@ export class EmailAndPasswordService<TContext extends AnyContextable> {
       this.schema.verification.config.prismaModelName
     ].findUnique({
       where: { [identifierField.name]: identifier.value },
-    })) as InferTableType<AnyVerificationTable> | undefined
+    })) as InferTableType<PluginSchema['verification']> | undefined
 
     if (!verification || verification.expiredAt < new Date()) {
       throw new HttpInternalServerError('Reset password token not found or expired')


### PR DESCRIPTION
# Why did you create this PR

<!-- Please add a link of the Ticket -->

- Some use case there's no need to put userId to verification table e.g. `signUpOtp`

# What did you do

- Make it optional
- Fix type of input plugin schema to be more flexible

# Screenshots / Recordings

# Checklist

- [ ] Self-reviewed your code
- [ ] Wrote coverage tests
- [ ] Added screenshots or recordings if applicable
