### PR TITLE
[Fix] Allow passing options for setting cookie via response helper

### DIFF
--- a/packages/react/src/auth/plugins/email-and-password/api/login.ts
+++ b/packages/react/src/auth/plugins/email-and-password/api/login.ts
@@ -29,7 +29,7 @@ export function loginEmail<
 
       // Create session
       const { sessionToken, expiredAt } = await service.createSession({ userId: userId })
-      ResponseHelper.setSessionCookie(response, sessionToken, { expiredAt })
+      ResponseHelper.setSessionCookie(response, sessionToken, { expires: expiredAt })
 
       return {
         status: 200 as const,

--- a/packages/react/src/auth/utils.ts
+++ b/packages/react/src/auth/utils.ts
@@ -1,4 +1,4 @@
-import { parse as parseCookies, serialize } from 'cookie-es'
+import { type CookieSerializeOptions, parse as parseCookies, serialize } from 'cookie-es'
 import crypto, { randomBytes } from 'crypto'
 import { promisify } from 'util'
 
@@ -12,13 +12,14 @@ export function getSessionCookie(request: Request): string | undefined {
 }
 
 export abstract class ResponseHelper {
-  static setSessionCookie(response: Response, value: string, options: { expiredAt: Date }) {
+  static setSessionCookie(response: Response, value: string, options: CookieSerializeOptions) {
     response.headers.set(
       'Set-Cookie',
       serialize(SESSION_COOKIE_NAME, value, {
         httpOnly: true,
-        expires: options.expiredAt,
+        path: '/',
         sameSite: 'strict',
+        ...options,
       })
     )
   }


### PR DESCRIPTION
# Why did you create this PR

<!-- Please add a link of the Ticket -->

# What did you do

- Add default `path` to `/`
- Change options type from only `{ expired: Date }` to full options type 

# Screenshots / Recordings

# Checklist

- [ ] Self-reviewed your code
- [ ] Wrote coverage tests
- [ ] Added screenshots or recordings if applicable
