### PR TITLE
[Fix] Use `createEndpoint` for `builder.endpoint`

### DIFF
--- a/.changeset/great-months-whisper.md
+++ b/.changeset/great-months-whisper.md
@@ -1,0 +1,5 @@
+---
+"@genseki/react": patch
+---
+
+[Fix] Use `createEndpoint` for `builder.endpoint`

--- a/packages/react/src/core/builder.tsx
+++ b/packages/react/src/core/builder.tsx
@@ -23,6 +23,7 @@ import {
   type ApiRouteSchema,
   type AppendApiPathPrefix,
   appendApiPathPrefix,
+  createEndpoint,
 } from './endpoint'
 import { FieldBuilder, type Fields, type FieldsShape } from './field'
 import type { ModelSchemas } from './model'
@@ -351,16 +352,7 @@ export class Builder<TModelSchemas extends ModelSchemas, in out TContext extends
     schema: TApiEndpointSchema,
     handler: ApiRouteHandlerInitial<ContextToRequestContext<TContext>, TApiEndpointSchema>
   ): ApiRoute<TApiEndpointSchema> {
-    return {
-      schema: schema,
-      handler: (payload, { request, response }) => {
-        const context = this.config.context.toRequestContext(request)
-        return handler(
-          { ...payload, context: context as ContextToRequestContext<TContext> },
-          { request, response }
-        )
-      },
-    }
+    return createEndpoint(this.config.context, schema, handler)
   }
 }
 


### PR DESCRIPTION
# Why did you create this PR

<!-- Please add a link of the Ticket -->

- builder.endpoint does not have `withValidator` logic

# What did you do

- use `createEndpoint` under the hood of `builder.endpoint`

# Screenshots / Recordings

# Checklist

- [ ] Self-reviewed your code
- [ ] Wrote coverage tests
- [ ] Added screenshots or recordings if applicable
