### PR TITLE
fix: Redundant `CollectionListViewProvider`

### DIFF
--- a/.changeset/flat-poems-wave.md
+++ b/.changeset/flat-poems-wave.md
@@ -1,0 +1,9 @@
+---
+'@example/erp': patch
+'@genseki/react': patch
+---
+
+- remove redundant `CollectionListViewProvider`
+- `useTableStatesContext` return correct `search` valie
+- `useSearch` return the user defined controlled value
+- renamed `pages` to `page` in list UI config

--- a/examples/erp/genseki/collections/posts.tsx
+++ b/examples/erp/genseki/collections/posts.tsx
@@ -207,14 +207,13 @@ const list = builder.list(fields, {
             <CollectionSidebar />
             <SidebarInset>
               <TopbarNav />
-
               <div>{args.children}</div>
             </SidebarInset>
           </SidebarProvider>
         </>
       )
     },
-    pages(args) {
+    page(args) {
       const ListViewContainer = args.ListViewContainer
       const ListView = args.ListView
       const Banner = args.Banner

--- a/packages/react/src/core/collection.ts
+++ b/packages/react/src/core/collection.ts
@@ -383,7 +383,7 @@ interface CustomCollectionUI<
   TFields extends Fields = Fields,
 > {
   layout?: CustomCollectionLayout
-  pages?: CustomCollectionPage<TFields>
+  page?: CustomCollectionPage<TFields>
 }
 
 export type CollectionListConfig<

--- a/packages/react/src/core/custom-collection/custom-list-page.tsx
+++ b/packages/react/src/core/custom-collection/custom-list-page.tsx
@@ -5,7 +5,7 @@ import {
   AppTopbarNav as _AppTopbarNav,
   Banner,
   CollectionLayout as _CollectionLayout,
-  CollectionListView as _ListView,
+  CollectionListView as _CollectionListView,
   CollectionListViewProvider,
   ListViewContainer,
   type ListViewContainerProps,
@@ -84,7 +84,7 @@ export function generateCustomCollectionListUI<
         )
       }
       const ListView = () => {
-        const NewListView = customCollectionArgs.listConfig.uis?.pages
+        const NewListView = customCollectionArgs.listConfig.uis?.page
         const clientListViewProps = getClientListViewProps(listViewProps)
 
         if (NewListView) {
@@ -92,7 +92,7 @@ export function generateCustomCollectionListUI<
             <CollectionListViewProvider clientListViewProps={clientListViewProps}>
               <NewListView
                 Banner={_Banner}
-                ListView={() => <_ListView {...listViewProps} />}
+                ListView={() => <_CollectionListView />}
                 ListViewContainer={_ListViewContainer}
                 listViewProps={listViewProps}
               />
@@ -100,12 +100,16 @@ export function generateCustomCollectionListUI<
           )
         }
 
-        return <_ListView {...listViewProps} />
+        return (
+          <CollectionListViewProvider clientListViewProps={clientListViewProps}>
+            <_CollectionListView />
+          </CollectionListViewProvider>
+        )
       }
 
       if (
         !customCollectionArgs.listConfig.uis?.layout &&
-        !customCollectionArgs.listConfig.uis?.pages
+        !customCollectionArgs.listConfig.uis?.page
       ) {
         return (
           <CollectionLayout>

--- a/packages/react/src/react/providers/table.tsx
+++ b/packages/react/src/react/providers/table.tsx
@@ -40,7 +40,7 @@ const TableStatesContext = createContext<TanstackTableContextValue>(null!)
 export const TableStatesProvider = (props: TableStatesProviderProps) => {
   const { pagination, setPagination } = usePagination()
   const { sort, setSort } = useSort()
-  const { search, setSearch } = useSearch()
+  const { debouncedSearch, setSearch } = useSearch()
   // row selection does not maintain a state wih URL search parameter like pagination and search
   const [rowSelection, setRowSelection] = useState<RowSelectionState>({})
 
@@ -58,7 +58,7 @@ export const TableStatesProvider = (props: TableStatesProviderProps) => {
         setPagination,
         sort,
         setSort,
-        search,
+        search: debouncedSearch,
         setSearch,
         rowSelection,
         rowSelectionIds,

--- a/packages/react/src/react/views/collections/list/index.tsx
+++ b/packages/react/src/react/views/collections/list/index.tsx
@@ -1,15 +1,5 @@
 import { ClientCollectionListView } from './list.client'
-import { CollectionListViewProvider } from './providers'
 
-import type { CollectionListViewProps } from '../../../../core/collection'
-import { getClientListViewProps } from '../../../../core/config'
-
-export async function CollectionListView(props: CollectionListViewProps) {
-  const clientListViewProps = getClientListViewProps(props)
-
-  return (
-    <CollectionListViewProvider clientListViewProps={clientListViewProps}>
-      <ClientCollectionListView />
-    </CollectionListViewProvider>
-  )
+export async function CollectionListView() {
+  return <ClientCollectionListView />
 }

--- a/packages/react/src/react/views/collections/list/list.client.tsx
+++ b/packages/react/src/react/views/collections/list/list.client.tsx
@@ -46,7 +46,7 @@ export function ClientCollectionListView() {
   const navigation = useNavigation()
   const queryClient = useQueryClient()
   const listViewProps = useListViewPropsContext()
-  const { pagination, isRowsSelected, rowSelectionIds, setRowSelection } = useTableStatesContext()
+  const { pagination, isRowsSelected, setRowSelection, rowSelectionIds } = useTableStatesContext()
 
   const query = useCollectionListQuery({ slug: listViewProps.slug })
 
@@ -77,9 +77,9 @@ export function ClientCollectionListView() {
                 <Checkbox
                   isSelected={table.getIsAllRowsSelected()}
                   isIndeterminate={table.getIsSomeRowsSelected()}
-                  onChange={(checked) =>
+                  onChange={(checked) => {
                     table.getToggleAllRowsSelectedHandler()({ target: { checked } })
-                  }
+                  }}
                 />
               ),
               cell: ({ row }) => (

--- a/packages/react/src/react/views/collections/list/toolbar/search.tsx
+++ b/packages/react/src/react/views/collections/list/toolbar/search.tsx
@@ -43,8 +43,8 @@ export function CollectionListSearch(props: CollectionListSearchProps) {
       prefix={<BaseIcon icon={MagnifyingGlassIcon} size="md" />}
       className="w-full"
       isPending={props.isLoading}
-      value={search}
-      onChange={setSearch}
+      value={props.search ?? search}
+      onChange={props.onSearchChange ?? setSearch}
     />
   )
 }


### PR DESCRIPTION
…text` search value.

# Why did you create this PR

- `CollectionListViewProvider` is redundant after `custom-list-page` render the `ListView`.
- `useTableStatesContext` return the wrong `search` value, it must be `debouncedSearch`.
- `useSearch` used to explicit return the internal search value state, now it returns `props.search`, `props.onSearch` if user provided.

<!-- Please add a link of the Ticket -->

# What did you do

- remove redundant `CollectionListViewProvider`
- `useTableStatesContext` return correct `search` valie
- `useSearch` return the user defined controlled value
- renamed `pages` to `page` in list UI config


# Checklist

- [x] Self-reviewed your code
- [ ] Wrote coverage tests
- [ ] Added screenshots or recordings if applicable
