### PR TITLE
[Fix] `RecordifyFlattenApiRouter` type does not work 

### DIFF
--- a/.changeset/thick-icons-invite.md
+++ b/.changeset/thick-icons-invite.md
@@ -1,0 +1,7 @@
+---
+"@genseki/plugins": patch
+"@genseki/react": patch
+---
+
+- fix `RecordifyFlattenApiRouter` wrong implementation
+- fix wrong phone plguin login path

--- a/packages/plugins/src/phone/index.ts
+++ b/packages/plugins/src/phone/index.ts
@@ -20,7 +20,7 @@ export function phone<
     context,
     {
       method: 'POST',
-      path: '/auth/phone/sign-up/otp',
+      path: '/auth/phone/login',
       body: z.object({
         phone: z.string().min(1),
         password: z.string().min(1),

--- a/packages/react/src/core/endpoint.ts
+++ b/packages/react/src/core/endpoint.ts
@@ -59,12 +59,11 @@ export function flattenApiRoutes<TApiRouter extends AnyApiRouter>(
   return flattened as FlattenApiRoutes<TApiRouter>
 }
 
-export type RecordifyFlattenApiRouter<TApiRoutes extends ApiRoute[]> =
-  TApiRoutes[number] extends infer TApiRoute extends ApiRoute
-    ? {
-        [K in `${TApiRoute['schema']['method']} ${TApiRoute['schema']['path']}`]: TApiRoute
-      }
-    : never
+export type RecordifyFlattenApiRouter<TApiRoutes extends ApiRoute[]> = {
+  [TApiRoute in TApiRoutes[number] as TApiRoute extends ApiRoute
+    ? `${TApiRoute['schema']['method']} ${TApiRoute['schema']['path']}`
+    : never]: TApiRoute extends ApiRoute ? TApiRoute : never
+}
 
 export function recordifyFlattenApiRoutes<TApiRoutes extends ApiRoute[]>(
   routes: TApiRoutes
@@ -93,7 +92,6 @@ export type FilterByMethod<TApiRoute extends ApiRoute, TMethod extends string> =
   { schema: { method: TMethod } }
 >
 
-// TODO: With IsNever, the performance is not good. Need to fix it.
 type GetBody<TApiRouteSchema extends ApiRouteSchema> =
   IsNever<TApiRouteSchema['body']> extends false ? Output<TApiRouteSchema['body']> : never
 

--- a/packages/react/src/core/endpoint.ts
+++ b/packages/react/src/core/endpoint.ts
@@ -62,7 +62,7 @@ export function flattenApiRoutes<TApiRouter extends AnyApiRouter>(
 export type RecordifyFlattenApiRouter<TApiRoutes extends ApiRoute[]> = {
   [TApiRoute in TApiRoutes[number] as TApiRoute extends ApiRoute
     ? `${TApiRoute['schema']['method']} ${TApiRoute['schema']['path']}`
-    : never]: TApiRoute extends ApiRoute ? TApiRoute : never
+    : never]: TApiRoute
 }
 
 export function recordifyFlattenApiRoutes<TApiRoutes extends ApiRoute[]>(


### PR DESCRIPTION
# Why did you create this PR

<!-- Please add a link of the Ticket -->

- Wrong phone plugin login path 
- type utility `RecordifyFlattenApiRouter` does not infer correct type

# What did you do

- Fix phone plugin login path 
- Extract the actual value of `RecordifyFlattenApiRouter` instead of all union. For example


Before
```tsx
type X = RecordifyFlattenApiRouter<typeof api> 
/*
* type X = {
*   "POST /some/path": ApiRoute<...> |  ApiRoute<...> | ApiRoute<...>
* }
**/
```

After 

```tsx
type X = RecordifyFlattenApiRouter<typeof api> 
/*
* type X = {
*   "POST /some/path": ApiRoute<...>
* }
**/
```

# Screenshots / Recordings

# Checklist

- [ ] Self-reviewed your code
- [ ] Wrote coverage tests
- [ ] Added screenshots or recordings if applicable
