### PR TITLE
[Feature] Enable provide pin to manual pin verification

### DIFF
--- a/packages/plugins/src/phone/store.ts
+++ b/packages/plugins/src/phone/store.ts
@@ -10,24 +10,27 @@ import {
 import { safeJsonParse } from './helper'
 import type { BaseSignUpBody, BaseSignUpBodySchema, PluginSchema } from './types'
 
-interface SignUpVerificationPayload<TSignUpBody extends BaseSignUpBody = BaseSignUpBody> {
+export interface SignUpVerificationPayload<TSignUpBody extends BaseSignUpBody = BaseSignUpBody> {
   phone: string
   password: string
   attempt: number
   data: TSignUpBody
+  pin?: string
 }
 
-interface ChangePhoneNumberVerificationPayload {
+export interface ChangePhoneNumberVerificationPayload {
   userId: string
   newPhone: string
   oldPhone: string
   attempt: number
+  pin?: string
 }
 
-interface ForgotPasswordVerificationPayload {
+export interface ForgotPasswordVerificationPayload {
   phone: string
   attempt: number
   userId: string
+  pin?: string
 }
 
 interface ResetPasswordVerificationPayload {
@@ -44,7 +47,6 @@ export abstract class PhoneStore<TSignUpBodySchema extends BaseSignUpBodySchema>
       data: {
         name: data.name,
         phone: data.phone,
-        email: data.email,
       },
     })) as { id: string }
 
@@ -133,7 +135,7 @@ export abstract class PhoneStore<TSignUpBodySchema extends BaseSignUpBodySchema>
 
   async getSignUpVerification(phone: string, refCode: string) {
     const verification = await this.prisma.verification.findFirst({
-      select: { id: true, value: true },
+      select: { id: true, value: true, createdAt: true, expiredAt: true },
       where: {
         identifier: `sign-up-phone:${phone}:${refCode}`,
         expiredAt: { gte: new Date() },
@@ -153,8 +155,10 @@ export abstract class PhoneStore<TSignUpBodySchema extends BaseSignUpBodySchema>
     }
 
     return {
-      id: verification.id,
+      id: verification.id as string,
       value: value,
+      createdAt: verification.createdAt as Date,
+      expiredAt: verification.expiredAt as Date,
     }
   }
 
@@ -249,7 +253,7 @@ export abstract class PhoneStore<TSignUpBodySchema extends BaseSignUpBodySchema>
 
   async getChangePhoneNumberVerification(userId: string, refCode: string) {
     const verification = await this.prisma.verification.findFirst({
-      select: { id: true, value: true },
+      select: { id: true, value: true, createdAt: true, expiredAt: true },
       where: {
         identifier: `change-phone:${userId}:${refCode}`,
         expiredAt: { gte: new Date() },
@@ -269,6 +273,8 @@ export abstract class PhoneStore<TSignUpBodySchema extends BaseSignUpBodySchema>
     return {
       id: verification.id as string,
       value: value,
+      createdAt: verification.createdAt as Date,
+      expiredAt: verification.expiredAt as Date,
     }
   }
 
@@ -337,12 +343,12 @@ export abstract class PhoneStore<TSignUpBodySchema extends BaseSignUpBodySchema>
 
   async getForgotPasswordVerification(phone: string, refCode: string) {
     const verification = (await this.prisma.verification.findFirst({
-      select: { id: true, value: true, createdAt: true },
+      select: { id: true, value: true, createdAt: true, expiredAt: true },
       where: {
         identifier: `forgot-password:${phone}:${refCode}`,
         expiredAt: { gte: new Date() },
       },
-    })) as { id: string; value: string; createdAt: Date } | null
+    })) as { id: string; value: string; createdAt: Date; expiredAt: Date } | null
 
     if (!verification) {
       return null
@@ -358,6 +364,7 @@ export abstract class PhoneStore<TSignUpBodySchema extends BaseSignUpBodySchema>
       id: verification.id,
       value: value,
       createdAt: verification.createdAt,
+      expiredAt: verification.expiredAt,
     }
   }
 

--- a/packages/plugins/src/phone/types.ts
+++ b/packages/plugins/src/phone/types.ts
@@ -13,7 +13,6 @@ export interface BaseSignUpBody {
   name: string
   phone: string
   password: string
-  email?: string
 }
 
 export type BaseSignUpBodySchema = ToZodObject<BaseSignUpBody>


### PR DESCRIPTION
# Why did you create this PR

<!-- Please add a link of the Ticket -->

To let user manually verify pin in `onOtpVerify` options. Which, sometimes, they need verify by themself, not third-party. Here's the use case


Case 1: Third Party manage PIN by itself.
```tsx
signUp: {
  onOtpSent: () => {
    // managed by third-party which does not return pin
    return { refCode: refCode, token: token }
  },
  onOtpVerify: () => {
    // verify via third-party
    return await ThirdPary.verify(pin)
  }
}
```

Case 2: PIN is managed by developers

```tsx
signUp: {
  onOtpSent: () => {
    // generated refCode, token, and PIN 
    return { refCode: refCode, token: token,  pin: pin }
  },
  // no need to provide onOtpVerify
}
```

# What did you do

-

# Screenshots / Recordings

# Checklist

- [x] Self-reviewed your code
- [ ] Wrote coverage tests
- [ ] Added screenshots or recordings if applicable
