### PR TITLE
fix: cancel select single dropdown

### DIFF
--- a/packages/react/src/react/components/compound/auto-field/index.tsx
+++ b/packages/react/src/react/components/compound/auto-field/index.tsx
@@ -243,6 +243,8 @@ export function AutoSelectField(props: AutoSelectField) {
       }}
       onSelectionChange={(value) => {
         if (value === null) return field.onChange(null)
+        if (value === field.value) return field.onChange(null)
+
         const selectedItem = items.find((item) => item.value === value)
         if (selectedItem) {
           field.onChange(selectedItem.value)


### PR DESCRIPTION
# Why did you create this PR

<!-- Please add a link of the Ticket -->
[[TTC-268 : Cancel Single Select Dropdown]
](https://linear.app/metier/issue/TTC-268/genseki-%E0%B9%84%E0%B8%A1%E0%B9%88%E0%B8%A1%E0%B8%B5-state-%E0%B8%A2%E0%B8%81%E0%B9%80%E0%B8%A5%E0%B8%B4%E0%B8%81%E0%B8%95%E0%B8%B1%E0%B8%A7%E0%B9%80%E0%B8%A5%E0%B8%B7%E0%B8%AD%E0%B8%81%E0%B9%83%E0%B8%99-single-select-dropdown)# What did you do

# Screenshots / Recordings

https://github.com/user-attachments/assets/df109c1e-d4b6-4ce7-9e43-006a07f6a87c


# Checklist

- [x] Self-reviewed your code
- [ ] Wrote coverage tests
- [x] Added screenshots or recordings if applicable
