### PR TITLE
fix: add min-height of richtext

### DIFF
--- a/.changeset/quiet-doors-repair.md
+++ b/.changeset/quiet-doors-repair.md
@@ -1,0 +1,5 @@
+---
+"@example/erp": patch
+---
+
+fix: add min-height of richtext

--- a/examples/erp/src/app/(admin)/admin/tiptap-style.css
+++ b/examples/erp/src/app/(admin)/admin/tiptap-style.css
@@ -148,7 +148,7 @@
 
   /* Selecting an image */
   img.ProseMirror-selectednode,
-  
+
   /* Selecting custom image */
   .ProseMirror-selectednode img {
     outline: 4px solid var(--color-primary);
@@ -410,6 +410,11 @@
       }
     }
   }
+}
+
+.tiptap.ProseMirror {
+  height: 100%;
+  min-height: 240px;
 }
 
 @keyframes image-loaded-fade-in {


### PR DESCRIPTION
# Why did you create this PR

<!-- Please add a link of the Ticket -->
- The richtext didn't have min height
# What did you do

- add style in tiptap.css

# Screenshots / Recordings
<img width="1920" height="1080" alt="ภาพถ่ายหน้าจอ 2568-09-22 เวลา 14 09 22 (2)" src="https://github.com/user-attachments/assets/f87f95da-ab12-4c96-b509-e67562eeccdd" />

# Checklist

- [x] Self-reviewed your code
- [ ] Wrote coverage tests
- [x] Added screenshots or recordings if applicable
