### PR TITLE
fix: change header to headers in querykey extraction

### DIFF
--- a/.changeset/wicked-turkeys-vanish.md
+++ b/.changeset/wicked-turkeys-vanish.md
@@ -1,0 +1,5 @@
+---
+'@genseki/react-query': patch
+---
+
+Change query key extraction spelling from `header` to `headers`

--- a/packages/react-query/src/index.ts
+++ b/packages/react-query/src/index.ts
@@ -216,7 +216,7 @@ export function queryKey(method: string, path: string | number | symbol, payload
     return [method, path] as const
   }
 
-  const { header: _header, ...rest } = payload
+  const { headers: _headers, ...rest } = payload
   const normalizedPayload = normalizeObject(rest)
 
   if (normalizedPayload) {


### PR DESCRIPTION
# Why did you create this PR

- Wrong spelling from `header` to `headers`

# What did you do

- Chnage key extraction name

# Screenshots / Recordings

# Checklist

- [ ] Self-reviewed your code
- [ ] Wrote coverage tests
- [ ] Added screenshots or recordings if applicable
