### PR TITLE
chore: genseki rawBody

### DIFF
--- a/packages/react/src/core/endpoint.ts
+++ b/packages/react/src/core/endpoint.ts
@@ -132,7 +132,7 @@ export type ApiRouteResponse<TResponses extends Partial<Record<ApiHttpStatus, In
 
 export type ApiRouteHandler<TApiRouteSchema extends ApiRouteSchema = ApiRouteSchema> = (
   payload: ApiRouteHandlerPayload<TApiRouteSchema>,
-  meta: { request: Request; response: Response }
+  meta: { request: Request; response: Response; rawBody?: string }
 ) => Promisable<ApiRouteResponse<TApiRouteSchema['responses']>>
 
 export type ApiRouteHandlerInitial<
@@ -140,7 +140,7 @@ export type ApiRouteHandlerInitial<
   TApiRouteSchema extends ApiRouteSchema,
 > = (
   payload: ApiRouteHandlerPayload<TApiRouteSchema> & { context: TContext },
-  meta: { request: Request; response: Response }
+  meta: { request: Request; response: Response; rawBody?: string }
 ) => Promisable<ApiRouteResponse<TApiRouteSchema['responses']>>
 
 export type GetApiRouteSchemaFromApiRouteHandler<TApiRouteHandler extends ApiRouteHandler<any>> =
@@ -225,11 +225,11 @@ export function createEndpoint<
 ): ApiRoute<TApiRouteSchema> {
   return {
     schema: schema,
-    handler: withValidator(schema, async (payload, { request, response }) => {
+    handler: withValidator(schema, async (payload, { request, response, rawBody }) => {
       const requestContext = context.toRequestContext(request) as ContextToRequestContext<TContext>
       const responseBody = await handler(
         { ...payload, context: requestContext },
-        { request, response }
+        { request, response, rawBody }
       )
       return responseBody
     }),

--- a/packages/react/src/core/endpoint.utils.ts
+++ b/packages/react/src/core/endpoint.utils.ts
@@ -12,7 +12,7 @@ export function withValidator<TApiRouteSchema extends ApiRouteSchema>(
 ): ApiRouteHandler<TApiRouteSchema> {
   const wrappedHandler = async (
     payload: ApiRouteHandlerPayload<TApiRouteSchema>,
-    { request, response }: { request: Request; response: Response }
+    { request, response, rawBody }: { request: Request; response: Response; rawBody?: string }
   ) => {
     const result = await validateRequestBody(schema, payload)
     if (result.success === false) {
@@ -26,7 +26,7 @@ export function withValidator<TApiRouteSchema extends ApiRouteSchema>(
     }
 
     const validatedPayload = result.data
-    const responseBody = await handler(validatedPayload as any, { request, response })
+    const responseBody = await handler(validatedPayload as any, { request, response, rawBody })
 
     const validationError = validateResponseBody(
       schema,


### PR DESCRIPTION
# Why did you create this PR

[Lazada Push Mechanism](https://open.lazada.com/apps/doc/doc?nodeId=29524&docId=120168)

To make sure the request is sent from Lazop and the request data is complete, Lazop will generate a signature and put it into request header. Client can reproduce the signature and compare it to the one receieved in message before consuming. 

Signature is generated by Hex-encoded HMAC-SHA256.

```
/*
Base = {your_app_key} + "{message_body_you_receieved}"
Secret = {your_app_Secret};
*/
Authorization = HEX_ENCODE(HMAC-SHA256(Base, Secret));
```

Then I need message_body_you_receieved (rawBody) from a Lazop to generate signature.

# What did you do

I remove `body = await req.json()` and keep it as a rawBody before parse to json. 

# Screenshots / Recordings

# Checklist

- [ ] Self-reviewed your code
- [ ] Wrote coverage tests
- [ ] Added screenshots or recordings if applicable
