### PR TITLE
fix: nuqs provider

### DIFF
--- a/.changeset/witty-turkeys-mix.md
+++ b/.changeset/witty-turkeys-mix.md
@@ -1,0 +1,5 @@
+---
+"@genseki/react": patch
+---
+
+fix: nuqs provider

--- a/legacies/react/src/react/providers/table.spec.tsx
+++ b/legacies/react/src/react/providers/table.spec.tsx
@@ -1,0 +1,86 @@
+import React from 'react'
+import { renderToStaticMarkup } from 'react-dom/server'
+
+import { describe, expect, it, vi } from 'vitest'
+
+import { TableStatesContextProvider, TableStatesProvider, useTableStatesContext } from './table'
+
+import type { UsePaginationReturn } from '../hooks/use-pagination'
+import type { UseSearchReturn } from '../hooks/use-search'
+import type { UseSort } from '../hooks/use-sort'
+
+const mockedPagination: UsePaginationReturn = {
+  pagination: { page: 2, pageSize: 25 },
+  setPagination: vi.fn(),
+}
+
+const mockedSearch: UseSearchReturn = {
+  search: 'seed-search',
+  setSearch: vi.fn(),
+}
+
+const mockedSort: { sort: UseSort['Sort']; setSort: UseSort['SetSort'] } = {
+  sort: [{ id: 'name', desc: false }],
+  setSort: vi.fn(),
+}
+
+vi.mock('../hooks/use-pagination', () => ({
+  usePagination: () => mockedPagination,
+}))
+
+vi.mock('../hooks/use-search', () => ({
+  useSearch: () => mockedSearch,
+}))
+
+vi.mock('../hooks/use-sort', () => ({
+  useSort: () => mockedSort,
+}))
+
+function TableStateProbe() {
+  const state = useTableStatesContext()
+
+  return (
+    <div data-testid="state">
+      {JSON.stringify({
+        page: state.pagination.page,
+        pageSize: state.pagination.pageSize,
+        search: state.search,
+        sort: state.sort,
+      })}
+    </div>
+  )
+}
+
+describe('TableStatesContextProvider', () => {
+  it('renders without NuqsAdapter and does not throw', () => {
+    expect(() =>
+      renderToStaticMarkup(
+        <TableStatesContextProvider
+          pagination={{ page: 1, pageSize: 10 }}
+          setPagination={vi.fn()}
+          sort={[]}
+          setSort={vi.fn()}
+          search=""
+          setSearch={vi.fn()}
+        >
+          <TableStateProbe />
+        </TableStatesContextProvider>
+      )
+    ).not.toThrow()
+  })
+})
+
+describe('TableStatesProvider', () => {
+  it('keeps legacy provider API behavior via nuqs-backed hooks', () => {
+    const html = renderToStaticMarkup(
+      <TableStatesProvider>
+        <TableStateProbe />
+      </TableStatesProvider>
+    )
+
+    expect(html).toContain('&quot;page&quot;:2')
+    expect(html).toContain('&quot;pageSize&quot;:25')
+    expect(html).toContain('&quot;search&quot;:&quot;seed-search&quot;')
+    expect(html).toContain('&quot;id&quot;:&quot;name&quot;')
+  })
+})

--- a/legacies/react/src/react/providers/table.tsx
+++ b/legacies/react/src/react/providers/table.tsx
@@ -35,12 +35,19 @@ interface TableStatesProviderProps {
   children?: React.ReactNode
 }
 
+export interface TableStatesContextProviderProps extends TableStatesProviderProps {
+  pagination: UsePaginationReturn['pagination']
+  setPagination: UsePaginationReturn['setPagination']
+  sort: UseSort['Sort']
+  setSort: UseSort['SetSort']
+  search: UseSearchReturn['search']
+  setSearch: UseSearchReturn['setSearch']
+}
+
 const TableStatesContext = createContext<TanstackTableContextValue>(null!)
 
-export const TableStatesProvider = (props: TableStatesProviderProps) => {
-  const { pagination, setPagination } = usePagination()
-  const { sort, setSort } = useSort()
-  const { search, setSearch } = useSearch()
+export const TableStatesContextProvider = (props: TableStatesContextProviderProps) => {
+  const { children, pagination, setPagination, sort, setSort, search, setSearch } = props
   // row selection does not maintain a state wih URL search parameter like pagination and search
   const [rowSelection, setRowSelection] = useState<RowSelectionState>({})
 
@@ -66,8 +73,27 @@ export const TableStatesProvider = (props: TableStatesProviderProps) => {
         isRowsSelected,
       }}
     >
-      {props.children}
+      {children}
     </TableStatesContext>
+  )
+}
+
+export const TableStatesProvider = (props: TableStatesProviderProps) => {
+  const { pagination, setPagination } = usePagination()
+  const { sort, setSort } = useSort()
+  const { search, setSearch } = useSearch()
+
+  return (
+    <TableStatesContextProvider
+      pagination={pagination}
+      setPagination={setPagination}
+      sort={sort}
+      setSort={setSort}
+      search={search}
+      setSearch={setSearch}
+    >
+      {props.children}
+    </TableStatesContextProvider>
   )
 }
 

--- a/legacies/react/src/react/views/collections/list/hooks/use-collection-list.ts
+++ b/legacies/react/src/react/views/collections/list/hooks/use-collection-list.ts
@@ -1,9 +1,9 @@
 import { keepPreviousData, useQuery, type UseQueryResult } from '@tanstack/react-query'
 
 import type { CollectionListResponse } from '../../../../../core/collection'
-import { usePagination, type UsePaginationReturn } from '../../../../hooks/use-pagination'
-import { useSearch, type UseSearchReturn } from '../../../../hooks/use-search'
-import { useSort } from '../../../../hooks/use-sort'
+import type { UsePaginationReturn } from '../../../../hooks/use-pagination'
+import type { UseSearchReturn } from '../../../../hooks/use-search'
+import { useTableStatesContext } from '../../../../providers/table'
 
 export function useCollectionListQuery(
   args: { slug: string } & {
@@ -11,9 +11,7 @@ export function useCollectionListQuery(
     search?: UseSearchReturn['search']
   }
 ) {
-  const { sort } = useSort()
-  const { pagination } = usePagination()
-  const { search } = useSearch()
+  const { sort, pagination, search } = useTableStatesContext()
 
   const queryKey = {
     ...(args.pagination || pagination),

--- a/legacies/react/src/react/views/collections/list/table/pagination.tsx
+++ b/legacies/react/src/react/views/collections/list/table/pagination.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { PageSizeSelect, Pagination } from '../../../../components'
-import { usePagination } from '../../../../hooks/use-pagination'
+import { useTableStatesContext } from '../../../../providers/table'
 import { useCollection } from '../../context'
 import { useCollectionListQuery } from '../hooks/use-collection-list'
 
@@ -12,7 +12,7 @@ export interface CollectionListPaginationProps {
 export function CollectionListPagination(props: CollectionListPaginationProps) {
   const context = useCollection()
 
-  const { pagination, setPagination } = usePagination()
+  const { pagination, setPagination } = useTableStatesContext()
 
   const query = useCollectionListQuery({ slug: context.slug })
 

--- a/legacies/react/src/react/views/collections/list/toolbar/search.tsx
+++ b/legacies/react/src/react/views/collections/list/toolbar/search.tsx
@@ -7,7 +7,7 @@ import { useControllableState } from '@radix-ui/react-use-controllable-state'
 import { Input } from '../../../../../../v2'
 import { InputGroup, InputGroupAddon, InputGroupControl } from '../../../../components'
 import { useDebounce } from '../../../../hooks/use-debounce'
-import { useSearch } from '../../../../hooks/use-search'
+import { useTableStatesContext } from '../../../../providers/table'
 
 export interface CollectionListSearchProps {
   placeholder?: string
@@ -22,7 +22,7 @@ export interface CollectionListSearchProps {
  * @param props.isLoading A loading state
  */
 export function CollectionListSearch(props: CollectionListSearchProps) {
-  const { search: paramSearch, setSearch: setParamSearch } = useSearch()
+  const { search: paramSearch, setSearch: setParamSearch } = useTableStatesContext()
   const [search, onSearch] = useControllableState({
     prop: props.search,
     onChange: props.onSearchChange,


### PR DESCRIPTION
# Why did you create this PR

<img width="971" height="547" alt="image" src="https://github.com/user-attachments/assets/706f584a-7cf9-4cae-b03b-02c80c2ddca5" />

## Problem
Collection list UI and related hooks called nuqs directly (useSearch, usePagination, useSort). In a Next.js App Router consumer, those hooks require a valid nuqs adapter boundary. When components render outside that boundary (or before the adapter is available), runtime throws [nuqs] NUQS-404.

## Solution
- Introduced TableStatesContextProvider: a pure React context provider that accepts search / pagination / sort state and setters via props. It does not call nuqs, so table UI can render without NuqsAdapter as long as state is supplied.
- Kept TableStatesProvider as the legacy, backward-compatible API: it still wires state through the existing nuqs hooks and passes them into TableStatesContextProvider.
- Updated list components and the list query hook to read search / pagination / sort from useTableStatesContext() instead of calling nuqs hooks directly (CollectionListSearch, CollectionListPagination, useCollectionListQuery).
- Added Vitest coverage: one test renders under TableStatesContextProvider without NuqsAdapter (no throw), and one test asserts TableStatesProvider still exposes the expected state when nuqs hooks are mocked.

## Compatibility / risk
- Public names preserved (TableStatesProvider, useTableStatesContext); new export: TableStatesContextProvider (+ its props type).
- Consumers using TableStatesProvider unchanged; any direct nuqs usage elsewhere in the app can still throw if not under the correct adapter—this change addresses the lib’s table/list path specifically.

# Screenshots / Recordings

# Checklist

- [ ] Self-reviewed your code
- [ ] Wrote coverage tests
- [ ] Added screenshots or recordings if applicable
